### PR TITLE
fix(ci/db): add -format bytes to bbolt get

### DIFF
--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: save vuls.db schema_version
         id: save_scheme_version
-        run: echo "schema_version=$(bbolt get ./vuls.db "metadata" "db" | jq .schema_version)" >> $GITHUB_OUTPUT
+        run: echo "schema_version=$(bbolt get -format bytes ./vuls.db "metadata" "db" | jq .schema_version)" >> $GITHUB_OUTPUT
 
       - name: compact vuls.db
         run: |


### PR DESCRIPTION
```console
root@b2a850390f60:/go/vuls-nightly-db# go install go.etcd.io/bbolt/cmd/bbolt@v1.3.11
root@b2a850390f60:/go/vuls-nightly-db# bbolt get --help
Usage:
  -format string
    	Output format. One of: auto|ascii-encoded|hex|bytes|redacted (default: bytes) (default "bytes")
  -h	
  -parse-format string
    	Input format. One of: ascii-encoded|hex (default: ascii-encoded) (default "ascii-encoded")

root@b2a850390f60:/go/vuls-nightly-db# go install go.etcd.io/bbolt/cmd/bbolt@latest
root@b2a850390f60:/go/vuls-nightly-db# bbolt get --help
Usage:
  -format string
    	Output format. One of: auto|ascii-encoded|hex|bytes|redacted (default: auto) (default "auto")
  -h	
  -parse-format string
    	Input format. One of: ascii-encoded|hex (default: ascii-encoded) (default "ascii-encoded")

root@b2a850390f60:/go/vuls-nightly-db# bbolt get -format bytes ./vuls.db "metadata" "db"
{"schema_version":0,"created_by":"vuls  ","last_modified":"2025-02-10T07:53:58.365543484Z"}

root@b2a850390f60:/go/vuls-nightly-db# bbolt get -format auto ./vuls.db "metadata" "db"
7b22736368656d615f76657273696f6e223a302c22637265617465645f6279223a2276756c732020222c226c6173745f6d6f646966696564223a22323032352d30322d31305430373a35333a35382e3336353534333438345a227d0a
```